### PR TITLE
Add shops_shipping_fee support to PurchaseRequest

### DIFF
--- a/src/DTO/ItemDetail.php
+++ b/src/DTO/ItemDetail.php
@@ -175,6 +175,8 @@ class ItemDetail
 
     public string $checksum;
 
+    public int $shops_shipping_fee;
+
     public function getUrl(): string
     {
         if ($this->isMercariC2C()) {

--- a/src/PurchaseRequest.php
+++ b/src/PurchaseRequest.php
@@ -69,5 +69,9 @@ class PurchaseRequest extends GenericRequest
         if (isset($item->item_discount->coupon_id)) {
             $this->coupon_id = $item->item_discount->coupon_id;
         }
+
+        if (isset($item->shops_shipping_fee)) {
+            $this->shops_shipping_fee = $item->shops_shipping_fee;
+        }
     }
 }

--- a/tests/PurchaseRequestTest.php
+++ b/tests/PurchaseRequestTest.php
@@ -97,4 +97,28 @@ class PurchaseRequestTest extends TestCase
         $this->assertSame($checksum, $request->checksum);
         $this->assertSame($variant_id, $request->variant_id);
     }
+
+    public function testFromShopItemWithShippingFee()
+    {
+        $item = new ItemDetail();
+        $item->id = '123123';
+        $item->checksum = 'FFFFF';
+        $item->shops_shipping_fee = 500;
+
+        $request = new PurchaseRequest($item);
+
+        $this->assertSame('123123', $request->item_id);
+        $this->assertSame(500, $request->shops_shipping_fee);
+    }
+
+    public function testFromC2CItemWithoutShippingFee()
+    {
+        $item = new ItemDetail();
+        $item->id = '123123';
+        $item->checksum = 'FFFFF';
+
+        $request = new PurchaseRequest($item);
+
+        $this->assertNull($request->shops_shipping_fee);
+    }
 }


### PR DESCRIPTION
Shop items require `shops_shipping_fee` for purchase (error `F0034`). 

The field is returned by the item API when `?prefecture=` is provided.